### PR TITLE
Refonte de la gestion des couleurs et des conflits du calendrier de prélèvement

### DIFF
--- a/src/components/declarations/month-prevelement-calendar.js
+++ b/src/components/declarations/month-prevelement-calendar.js
@@ -21,13 +21,8 @@ const DayCell = ({day, firstDayCurrentMonth, dataMap, renderTooltipContent, onDa
   let cellClasses = 'aspect-square rounded flex items-center justify-center text-xs transition-colors duration-150 ease-in-out'
 
   if (dayData) {
-    if (dayData.colorA && dayData.colorB) {
-      cellStyle = {
-        background: `repeating-linear-gradient(45deg, ${dayData.colorA}, ${dayData.colorA} 3px, ${dayData.colorB} 3px, ${dayData.colorB} 6px)`
-      }
-      cellClasses += ' text-white font-semibold'
-    } else if (dayData.colorA) {
-      cellStyle = {backgroundColor: dayData.colorA}
+    if (dayData.color) {
+      cellStyle = {backgroundColor: dayData.color}
       cellClasses += ' text-white font-semibold'
     }
   } else if (isCurrentMonthDay) {

--- a/src/components/declarations/prelevements-calendar.js
+++ b/src/components/declarations/prelevements-calendar.js
@@ -131,7 +131,7 @@ function buildMinuteItems(params, curr15, prev15) {
 /**
  * Détermine s’il existe :
  *  - un conflit « journalière » (différence de valeurs)
- *  - un conflit « 15min »   (différence de séries)
+ *  - un conflit « 15min » (différence de séries)
  *
  * @returns {{daily: boolean, minute: boolean}}
  */
@@ -142,10 +142,17 @@ function detectConflicts(current, previous, curr15, prev15) {
   )
 
   const minute = current.some((_, idx) => {
-    // Conflit 15min : séries différentes (au moins une valeur diffère)
-    const c = curr15.map(seg => seg?.values?.[idx])
-    const p = prev15.map(seg => seg?.values?.[idx])
-    return !isEqual(c, p)
+    const cSeries = curr15.map(seg => seg?.values?.[idx])
+    const pSeries = prev15.map(seg => seg?.values?.[idx])
+
+    const cHas = cSeries.some(val => isDeclared(val))
+    const pHas = pSeries.some(val => isDeclared(val))
+
+    if (!(cHas && pHas)) {
+      return false // Pas de données de part et d'autre => pas de conflit
+    }
+
+    return !isEqual(cSeries, pSeries)
   })
 
   return {daily, minute}

--- a/src/components/declarations/prelevements-calendar.js
+++ b/src/components/declarations/prelevements-calendar.js
@@ -1,5 +1,7 @@
 'use client'
 
+import {useMemo} from 'react'
+
 import {fr} from '@codegouvfr/react-dsfr'
 import {Alert} from '@codegouvfr/react-dsfr/Alert'
 import {
@@ -51,7 +53,9 @@ export function transformOutJsonToCalendarData(outJson) {
 }
 
 const PrelevementsCalendar = ({data}) => {
-  if (data.dailyValues && data.dailyValues.length === 0) {
+  const calendarData = useMemo(() => data.dailyValues && data.dailyValues.length > 0 ? transformOutJsonToCalendarData(data) : null, [data])
+
+  if (!data.dailyValues || data.dailyValues.length === 0) {
     return (
       <Alert severity='warning' description='Aucune donnée de prélèvement n’a été trouvée.' />
     )
@@ -59,7 +63,7 @@ const PrelevementsCalendar = ({data}) => {
 
   return (
     <CalendarGrid
-      data={transformOutJsonToCalendarData(data)}
+      data={calendarData}
       renderCustomTooltipContent={({date, dayStyleEntry}) => {
         if (!dayStyleEntry) {
           return (

--- a/src/components/declarations/prelevements-calendar.js
+++ b/src/components/declarations/prelevements-calendar.js
@@ -10,10 +10,10 @@ import {parseISO, format} from 'date-fns'
 import CalendarGrid from '@/components/calendar-grid.js'
 import {formatNumber} from '@/utils/number.js'
 
-function determineColors(values, fifteenMinutesValues, dailyParameters) {
+function determineColor(values, fifteenMinutesValues, dailyParameters) {
   const hasNegativeValue = values.some(v => v < 0)
   if (hasNegativeValue) {
-    return {colorA: fr.colors.decisions.background.flat.error.default, colorB: null}
+    return fr.colors.decisions.background.flat.error.default
   }
 
   const volumePreleveParam = dailyParameters?.find(p => p.nom_parametre === 'volume prélevé')
@@ -23,16 +23,16 @@ function determineColors(values, fifteenMinutesValues, dailyParameters) {
 
   if (volumePreleveIndex > -1 && !Number.isNaN(values[volumePreleveIndex])) {
     // Bleu si la donnée journalière pour le volume prélevé est présente
-    return {colorA: fr.colors.decisions.text.actionHigh.blueFrance.default, colorB: null}
+    return fr.colors.decisions.text.actionHigh.blueFrance.default
   }
 
   if (hasAnyData) {
     // Orange s'il y a d'autres données mais pas le volume prélevé journalier
-    return {colorA: fr.colors.decisions.background.flat.warning.default, colorB: null}
+    return fr.colors.decisions.background.flat.warning.default
   }
 
   // Gris si aucune donnée
-  return {colorA: 'grey', colorB: null}
+  return 'grey'
 }
 
 export function transformOutJsonToCalendarData(outJson) {
@@ -40,13 +40,12 @@ export function transformOutJsonToCalendarData(outJson) {
   return daily.map(({date, values, fifteenMinutesValues}) => {
     // Reformattage de la date pour dd-MM-yyyy
     const dateKey = format(parseISO(date), 'dd-MM-yyyy')
-    const {colorA, colorB} = determineColors(values, fifteenMinutesValues, outJson.dailyParameters)
+    const color = determineColor(values, fifteenMinutesValues, outJson.dailyParameters)
     return {
       date: dateKey,
       values,
       fifteenMinutesValues,
-      colorA,
-      colorB
+      color
     }
   })
 }

--- a/src/components/declarations/prelevements-calendar.js
+++ b/src/components/declarations/prelevements-calendar.js
@@ -1,15 +1,11 @@
 'use client'
 
-import {useState} from 'react'
-
 import {fr} from '@codegouvfr/react-dsfr'
 import {Alert} from '@codegouvfr/react-dsfr/Alert'
 import {
-  Box, Modal, Tab, Tabs, Typography
+  Box, Typography
 } from '@mui/material'
-import {LineChart} from '@mui/x-charts'
 import {parseISO, format} from 'date-fns'
-import {fr as locale} from 'date-fns/locale'
 
 import CalendarGrid from '@/components/calendar-grid.js'
 import {formatNumber} from '@/utils/number.js'
@@ -56,25 +52,6 @@ export function transformOutJsonToCalendarData(outJson) {
 }
 
 const PrelevementsCalendar = ({data}) => {
-  // États pour la modal et le paramètre sélectionné
-  const [open, setOpen] = useState(false)
-  const [selectedDayInfo, setSelectedDayInfo] = useState(null)
-  const [tabIndex, setTabIndex] = useState(0)
-
-  const fifteenParams = data.fifteenMinutesParameters || []
-
-  // Support for optional fifteenMinutesValues: fallback to empty array if null
-  const fifteenValues = selectedDayInfo?.dayStyleEntry?.fifteenMinutesValues || []
-
-  // Handlers
-  const handleDayClick = dayInfo => {
-    setSelectedDayInfo(dayInfo)
-    setTabIndex(0)
-    setOpen(true)
-  }
-
-  const handleClose = () => setOpen(false)
-
   if (data.dailyValues && data.dailyValues.length === 0) {
     return (
       <Alert severity='warning' description='Aucune donnée de prélèvement n’a été trouvée.' />
@@ -82,131 +59,38 @@ const PrelevementsCalendar = ({data}) => {
   }
 
   return (
-    <>
-      <CalendarGrid
-        data={transformOutJsonToCalendarData(data)}
-        renderCustomTooltipContent={({date, dayStyleEntry}) => {
-          if (!dayStyleEntry) {
-            return (
-              <>
-                <strong>{date.toLocaleDateString('fr-FR')}</strong>
-                <Typography>
-                  <Box component='span' className='fr-icon-warning-fill' /> Aucun donnée
-                </Typography>
-              </>
-            )
-          }
-
-          const {values} = dayStyleEntry
-          const warnings = values.map(v => v === null || v === undefined || v < 0)
-
+    <CalendarGrid
+      data={transformOutJsonToCalendarData(data)}
+      renderCustomTooltipContent={({date, dayStyleEntry}) => {
+        if (!dayStyleEntry) {
           return (
             <>
               <strong>{date.toLocaleDateString('fr-FR')}</strong>
-              {Object.keys(data.dailyParameters).map(paramIndex => (
-                <Typography key={paramIndex}>
-                  {data.dailyParameters[paramIndex].nom_parametre} : {Number.isNaN(values[paramIndex])
-                    ? '—'
-                    : formatNumber(values[paramIndex], values[paramIndex] < 1 && values[paramIndex] !== 0 ? {maximumFractionDigits: 2, minimumFractionDigits: 2} : {})} m³
-                  {warnings[0] && <Box component='span' className='fr-icon-warning-fill' />}
-                </Typography>
-              ))}
+              <Typography>
+                <Box component='span' className='fr-icon-warning-fill' /> Aucun donnée
+              </Typography>
             </>
           )
-        }}
-        onDayClick={fifteenValues.length > 0 ? handleDayClick : undefined}
-      />
+        }
 
-      <Modal open={open} onClose={handleClose}>
-        <Box sx={{
-          width: '80%', maxWidth: 600, bgcolor: 'background.paper', p: 2, mx: 'auto', mt: '10%'
-        }}
-        >
-          {selectedDayInfo && (
-            <>
-              <Typography gutterBottom variant='h6' component='h2'>
-                {selectedDayInfo.date.toLocaleDateString('fr-FR', {
-                  weekday: 'long', day: 'numeric', month: 'long', year: 'numeric'
-                })}
+        const {values} = dayStyleEntry
+        const warnings = values.map(v => v === null || v === undefined || v < 0)
+
+        return (
+          <>
+            <strong>{date.toLocaleDateString('fr-FR')}</strong>
+            {Object.keys(data.dailyParameters).map(paramIndex => (
+              <Typography key={paramIndex}>
+                {data.dailyParameters[paramIndex].nom_parametre} : {Number.isNaN(values[paramIndex])
+                  ? '—'
+                  : formatNumber(values[paramIndex], values[paramIndex] < 1 && values[paramIndex] !== 0 ? {maximumFractionDigits: 2, minimumFractionDigits: 2} : {})} m³
+                {warnings[0] && <Box component='span' className='fr-icon-warning-fill' />}
               </Typography>
-
-              <Box className='flex gap-2'>
-                {data.dailyParameters.map((param, idx) => (
-                  <Typography key={param.paramIndex}>
-                    {param.nom_parametre}: {
-                      Number.isNaN(selectedDayInfo.dayStyleEntry.values[idx])
-                        ? '—'
-                        : formatNumber(selectedDayInfo.dayStyleEntry.values[idx], {maximumFractionDigits: 2})
-                    } {param.unite}
-                  </Typography>
-                ))}
-              </Box>
-
-              {fifteenParams.length > 0 ? (
-                <Tabs
-                  variant='scrollable'
-                  value={tabIndex}
-                  onChange={(e, v) => setTabIndex(v)}
-                >
-                  {fifteenParams.map((param, idx) => {
-                    const missing = selectedDayInfo.dayStyleEntry.values[idx] === null
-                      || fifteenValues.some(slot => slot.values[idx] === null)
-                    return (
-                      <Tab
-                        key={param.paramIndex}
-                        label={
-                          <Box className='flex items-center gap-2'>
-                            {missing && <Box component='span' className='fr-icon-warning-fill' sx={{color: fr.colors.decisions.background.flat.warning.default}} />}
-                            {param.nom_parametre}
-                          </Box>
-                        }
-                      />
-                    )
-                  })}
-                </Tabs>
-              ) : (
-                <Alert severity='warning' description='Les données de prélèvement à 15 minutes ne sont pas disponibles.' />
-              )}
-              {fifteenParams.length > 0 ? (
-                <Box sx={{height: 300, mt: 2}}>
-                  <LineChart
-                    series={[{
-                      id: fifteenParams[tabIndex].nom_parametre,
-                      data: fifteenValues.map(slot =>
-                        slot.values[tabIndex]
-                      ),
-                      color: fr.colors.decisions.text.actionHigh.blueFrance.default,
-                      valueFormatter: value =>
-                        value === null
-                          ? 'Aucune donnée'
-                          : `${value} ${fifteenParams[tabIndex].unite}`
-                    }]}
-                    xAxis={[{
-                      scaleType: 'time',
-                      data: fifteenValues.map(slot =>
-                        parseISO(`${format(selectedDayInfo.date, 'yyyy-MM-dd')}T${slot.heure}`)
-                      ),
-                      valueFormatter(value) {
-                        const dateObj = value
-                        const hours = dateObj.getHours()
-                        const minutes = dateObj.getMinutes()
-                        // Major tick at midnight: show full date
-                        if (hours === 0 && minutes === 0) {
-                          return format(dateObj, 'EEEE d MMM', {locale})
-                        }
-
-                        // Otherwise show hour and minute
-                        return format(dateObj, 'HH:mm', {locale})
-                      }
-                    }]}
-                  />
-                </Box>
-              ) : null}
-            </>
-          )}
-        </Box>
-      </Modal>
-    </>
+            ))}
+          </>
+        )
+      }}
+    />
   )
 }
 

--- a/src/components/declarations/prelevements-calendar.js
+++ b/src/components/declarations/prelevements-calendar.js
@@ -1,10 +1,10 @@
 'use client'
 
-import {useMemo} from 'react'
+import {useCallback, useMemo} from 'react'
 
 import {fr} from '@codegouvfr/react-dsfr'
 import {Alert} from '@codegouvfr/react-dsfr/Alert'
-import {Box, Typography} from '@mui/material'
+import {Divider, Typography} from '@mui/material'
 import {parseISO, format} from 'date-fns'
 import {
   isEqual, keyBy, union, some as _some
@@ -13,52 +13,121 @@ import {
 import CalendarGrid from '@/components/calendar-grid.js'
 import {formatNumber} from '@/utils/number.js'
 
-/**
- * Indique si une entrée contient au moins une valeur numérique valide.
- */
+/* ------------------------------------------------------------------ */
+/* Utils                                                              */
+/* ------------------------------------------------------------------ */
+
+/** Retourne vrai si la valeur représente une déclaration (0 accepté). */
+function isDeclared(value) {
+  return value !== null && value !== undefined && !Number.isNaN(value)
+}
+
+/** Indique si une entrée contient au moins une valeur (journalière ou 15 min). */
 function hasValues(entry) {
   return (
     entry
-      && (_some(entry.values, v => !Number.isNaN(v))
-        || (entry.fifteenMinutesValues || []).length > 0)
+    && (_some(entry.values, isDeclared)
+      || (entry.fifteenMinutesValues || []).length > 0)
   )
 }
 
-/**
- * Détermine la couleur d’un jour donné selon la présence / égalité des données.
- */
+/** Détermine la couleur d’un jour donné selon la présence / égalité des données. */
 function determineColor(currentEntry, previousEntry) {
   const hasCurrent = hasValues(currentEntry)
   const hasPrevious = hasValues(previousEntry)
 
   if (!hasCurrent && !hasPrevious) {
-    return 'grey'
-  } // Aucune déclaration (gris)
+    return 'grey' // Aucune déclaration
+  }
 
   if (hasCurrent && !hasPrevious) {
-    return fr.colors.decisions.text.actionHigh.blueFrance.default
-  } // Nouvelle déclaration (bleu)
+    return fr.colors.decisions.text.actionHigh.blueFrance.default // Nouvelle
+  }
 
   if (!hasCurrent && hasPrevious) {
-    return fr.colors.decisions.background.flat.success.default
-  } // Déclaration déjà existante (vert)
+    return fr.colors.decisions.background.flat.success.default // Existante
+  }
 
-  // Les deux jeux de données existent : identiques ?
+  // Les deux jeux existent : identiques ?
   const identical
-     = isEqual(currentEntry.values, previousEntry.values)
-     && isEqual(
-       currentEntry.fifteenMinutesValues,
-       previousEntry.fifteenMinutesValues
-     )
+    = isEqual(currentEntry.values, previousEntry.values)
+    && isEqual(
+      currentEntry.fifteenMinutesValues,
+      previousEntry.fifteenMinutesValues
+    )
 
   return identical
-    ? fr.colors.decisions.background.flat.success.default // Déclaration inchangée (vert)
-    : fr.colors.decisions.background.flat.warning.default // Déclaration en conflit (orange)
+    ? fr.colors.decisions.background.flat.success.default // Identique
+    : fr.colors.decisions.background.flat.warning.default // Conflit
 }
 
-/**
-  * Construit le tableau attendu par <CalendarGrid/> en fusionnant data & previousData.
-  */
+/* ---------- Tooltip helpers to keep render function simple ---------- */
+
+function buildJournalierItems(params, current, previous) {
+  const journalier = []
+  const previousJournalier = []
+
+  for (const [idx, param] of params.entries()) {
+    const val = isDeclared(current[idx]) ? current[idx] : previous[idx]
+    if (isDeclared(val)) {
+      journalier.push(
+        <li key={`day-${idx}`}>
+          • {param.nom_parametre} : {formatNumber(val)} {param.unite ?? ''}
+        </li>
+      )
+    }
+
+    const delta
+      = isDeclared(current[idx]) && isDeclared(previous[idx])
+        ? current[idx] - previous[idx]
+        : null
+
+    previousJournalier.push(
+      <li key={`prev-day-${idx}`}>
+        • {param.nom_parametre} : {formatNumber(previous[idx])} {param.unite ?? ''}
+        {delta !== null && delta !== 0 && (
+          <> (Δ {delta > 0 ? '+' : ''}{formatNumber(delta)} {param.unite ?? ''})</>
+        )}
+      </li>
+    )
+  }
+
+  return {journalier, previousJournalier}
+}
+
+function buildMinuteItems(params, curr15, prev15) {
+  const items = []
+  for (const [idx, param] of params.entries()) {
+    const currSeg = curr15.map(seg => seg?.values?.[idx])
+    const prevSeg = prev15.map(seg => seg?.values?.[idx])
+    const hasMinute
+      = currSeg.some(v => isDeclared(v)) || prevSeg.some(v => isDeclared(v))
+    if (hasMinute) {
+      items.push(
+        <li key={`min-${idx}`}>
+          • {param.nom_parametre} en {param.unite ?? ''}
+        </li>
+      )
+    }
+  }
+
+  return items
+}
+
+function detectConflicts(current, previous, curr15, prev15) {
+  const daily = current.some(
+    (v, i) => isDeclared(v) && isDeclared(previous[i]) && v !== previous[i]
+  )
+
+  const minute = current.some((_, idx) => {
+    const c = curr15.map(seg => seg?.values?.[idx])
+    const p = prev15.map(seg => seg?.values?.[idx])
+    return !isEqual(c, p)
+  })
+
+  return {daily, minute}
+}
+
 export function transformDataToCalendarData(data = {}, previousData = {}) {
   const currentByDate = keyBy(data.dailyValues || [], 'date')
   const previousByDate = keyBy(previousData.dailyValues || [], 'date')
@@ -71,82 +140,109 @@ export function transformDataToCalendarData(data = {}, previousData = {}) {
 
     return {
       date: format(parseISO(isoDate), 'dd-MM-yyyy'),
+      currentValues: current?.values ?? [],
+      previousValues: previous?.values ?? [],
+      currentFifteenMinutesValues: current?.fifteenMinutesValues ?? [],
+      previousFifteenMinutesValues: previous?.fifteenMinutesValues ?? [],
+      // Legacy :
       values: current?.values ?? previous?.values ?? [],
       fifteenMinutesValues:
-         current?.fifteenMinutesValues ?? previous?.fifteenMinutesValues ?? [],
+        current?.fifteenMinutesValues ?? previous?.fifteenMinutesValues ?? [],
       color
-
     }
   })
 }
 
-/**
-  * Composant visuel principal.
-  */
 const PrelevementsCalendar = ({data, previousData}) => {
   const calendarData = useMemo(() => {
-    const hasAnyData
-       = (data?.dailyValues?.length ?? 0) > 0
-       || (previousData?.dailyValues?.length ?? 0) > 0
+    const hasAny
+      = (data?.dailyValues?.length ?? 0) > 0
+      || (previousData?.dailyValues?.length ?? 0) > 0
+    return hasAny ? transformDataToCalendarData(data, previousData) : null
+  }, [data, previousData])
 
-    return hasAnyData
-      ? transformDataToCalendarData(data, previousData)
-      : null
+  const renderCustomTooltipContent = useCallback(({date, dayStyleEntry}) => {
+    if (!dayStyleEntry) {
+      return (
+        <div className='flex flex-col gap-2'>
+          <Typography>{date.toLocaleDateString('fr-FR')}</Typography>
+          <Typography>Aucune donnée</Typography>
+        </div>
+      )
+    }
+
+    const {currentValues, previousValues} = dayStyleEntry
+    const curr15 = dayStyleEntry.currentFifteenMinutesValues
+    const prev15 = dayStyleEntry.previousFifteenMinutesValues
+
+    const params
+      = data?.dailyParameters?.length > 0
+        ? data.dailyParameters
+        : previousData?.dailyParameters ?? []
+
+    const {journalier, previousJournalier} = buildJournalierItems(
+      params,
+      currentValues,
+      previousValues
+    )
+    const minuteItems = buildMinuteItems(params, curr15, prev15)
+    const {daily: dailyConflict, minute: minuteConflict} = detectConflicts(
+      currentValues,
+      previousValues,
+      curr15,
+      prev15
+    )
+
+    return (
+      <div className='flex flex-col gap-2'>
+        <Typography>{date.toLocaleDateString('fr-FR')}</Typography>
+
+        {journalier.length > 0 && (
+          <>
+            <div>Prélèvement journalier :</div>
+            <ul>{journalier}</ul>
+          </>
+        )}
+        {(dailyConflict) && (
+          <div>
+            <span className='fr-icon-warning-fill' /> Cette déclaration est en conflit avec la précédente
+          </div>
+        )}
+        {dailyConflict && previousJournalier.length > 0 && (
+          <ul>{previousJournalier}</ul>
+        )}
+
+        <Divider component='div' />
+
+        {minuteItems.length > 0 && (
+          <>
+            <div>Prélèvement 15 minutes :</div>
+            <ul>{minuteItems}</ul>
+          </>
+        )}
+
+        {(minuteConflict) && (
+          <div>
+            <span className='fr-icon-warning-fill' /> Au moins un des paramètres de cette déclaration est en conflit avec la précédente.
+          </div>
+        )}
+      </div>
+    )
   }, [data, previousData])
 
   if (!calendarData) {
     return (
-      <Alert severity='warning' description='Aucune donnée de prélèvement n’a été trouvée.' />
+      <Alert
+        severity='warning'
+        description='Aucune donnée de prélèvement n’a été trouvée.'
+      />
     )
   }
-
-  const dailyParameters
-     = data?.dailyParameters?.length > 0
-       ? data.dailyParameters
-       : previousData?.dailyParameters ?? []
 
   return (
     <CalendarGrid
       data={calendarData}
-      renderCustomTooltipContent={({date, dayStyleEntry}) => {
-        if (!dayStyleEntry) {
-          return (
-            <>
-              <strong>{date.toLocaleDateString('fr-FR')}</strong>
-              <Typography>
-                <Box component='span' className='fr-icon-warning-fill' /> Aucun donnée
-              </Typography>
-            </>
-          )
-        }
-
-        const {values} = dayStyleEntry
-        const warnings = values.map(v => v === null || v === undefined || v < 0)
-
-        return (
-          <>
-            <strong>{date.toLocaleDateString('fr-FR')}</strong>
-            {dailyParameters.map((param, index) => (
-              <Typography key={param.nom_parametre}>
-                {param.nom_parametre} :{' '}
-                {Number.isNaN(values[index])
-                  ? '—'
-                  : formatNumber(
-                    values[index],
-                    values[index] < 1 && values[index] !== 0
-                      ? {maximumFractionDigits: 2, minimumFractionDigits: 2}
-                      : {}
-
-                  )}{' '}
-                m³
-                {warnings[index] && (
-                  <Box component='span' className='fr-icon-warning-fill' />
-                )}
-              </Typography>
-            ))}
-          </>
-        )
-      }}
+      renderCustomTooltipContent={renderCustomTooltipContent}
     />
   )
 }


### PR DESCRIPTION
## Description
Cette pull request refond la manière dont le calendrier des prélèvements affiche les informations, en se concentrant sur une meilleure gestion des couleurs pour représenter l'état des déclarations et la comparaison avec les données précédentes.

### Changements principaux

1. Nouvelle logique de couleurs et comparaison des données
  - Le composant `<PrelevementsCalendar/>` accepte désormais une nouvelle prop `previousData`. Cela permet de comparer la déclaration actuelle avec une déclaration précédente.
  - La logique de coloration des jours du calendrier a été entièrement revue pour refléter
    cette comparaison :
      - Bleu : Nouvelle déclaration (données présentes dans data mais pas dans `previousData`).
      - Vert : Déclaration existante et/ou inchangée.
      - Orange : Conflit (différences entre `data` et `previousData`).
      - Gris : Aucune donnée de prélèvement connue pour ce jour.
  - La fonction `determineColor` a été refactorisée pour implémenter cette nouvelle logique de manière claire et maintenable.

2. Amélioration des infobulles (Tooltips)
  - Les infobulles affichent maintenant clairement les conflits entre la déclaration actuelle et la précédente.
  - En cas de conflit sur les valeurs journalières, un delta (Δ) est affiché pour visualiser rapidement la différence.
  - Le code des infobulles, devenu plus complexe, a été mieux documenté pour faciliter la compréhension des calculs et de la logique d'affichage.

3. Nettoyage du code
  - La fonctionnalité `onDayClick`, qui n'était pas utilisée, a été retirée du composant `<MonthPrelevementCalendar/>` pour simplifier le code.
  - La logique complexe de `<PrelevementsCalendar/>` a été décomposée en fonctions utilitaires plus petites et spécialisées (`buildJournalierItems`, `buildMinuteItems`, `detectConflicts`), améliorant ainsi la lisibilité et la maintenance du composant.

### Preview
<img width="612" height="536" alt="Capture d’écran 2025-08-01 à 15 10 53" src="https://github.com/user-attachments/assets/936804d6-e118-40f6-85f8-97af2763ccdf" />
