### PR TITLE
Modification de l'utilisation des identifiants

### DIFF
--- a/src/app/prelevements/[id]/layout.js
+++ b/src/app/prelevements/[id]/layout.js
@@ -19,7 +19,7 @@ const Layout = async ({params, children}) => {
       <div className='fr-container mt-4'>
 
         <Breadcrumb
-          currentPageLabel={`${id} - ${pointPrelevement.nom}`}
+          currentPageLabel={`${pointPrelevement.id_point} - ${pointPrelevement.nom}`}
           segments={[{
             label: 'Points de prélèvement',
             linkProps: {

--- a/src/app/preleveurs/[id]/page.js
+++ b/src/app/preleveurs/[id]/page.js
@@ -34,7 +34,7 @@ const Page = async ({params}) => {
                 priority='secondary'
                 iconId='fr-icon-edit-line'
                 linkProps={{
-                  href: `/preleveurs/${preleveur.id_preleveur}/edit`
+                  href: `/preleveurs/${preleveur._id}/edit`
                 }}
               >
                 Éditer
@@ -74,8 +74,8 @@ const Page = async ({params}) => {
         <div><b>Points de prélevement : </b>
           {points && points.length > 0 ? (
             points.map(point => (
-              <div key={point.id_point}>
-                <Link href={`/prelevements/${point.id_point}`}>
+              <div key={point._id}>
+                <Link href={`/prelevements/${point._id}`}>
                   {point.id_point} - {point.nom}
                 </Link>
               </div>

--- a/src/components/form/exploitation-creation-form.js
+++ b/src/components/form/exploitation-creation-form.js
@@ -17,8 +17,8 @@ const ExploitationCreationForm = ({idPoint, points, preleveurs}) => {
   const [error, setError] = useState(null)
   const [validationErrors, setValidationErrors] = useState([])
   const [exploitation, setExploitation] = useState({
-    id_point: idPoint || '',
-    id_preleveur: '',
+    point: idPoint || '',
+    preleveur: '',
     date_debut: '',
     statut: '',
     documents: [],
@@ -43,7 +43,7 @@ const ExploitationCreationForm = ({idPoint, points, preleveurs}) => {
         }
       } else {
         // TODO : Rediriger vers la page exploitation quand elle sera terminée
-        router.push(`/prelevements/${response.id_point}`)
+        router.push(`/prelevements/${response.point}`)
       }
     } catch (error) {
       setError(error.message)
@@ -51,7 +51,7 @@ const ExploitationCreationForm = ({idPoint, points, preleveurs}) => {
   }
 
   useEffect(() => {
-    setIsDisabled(!(exploitation.id_point && exploitation.id_preleveur && exploitation.date_debut && exploitation.statut))
+    setIsDisabled(!(exploitation.point && exploitation.preleveur && exploitation.date_debut && exploitation.statut))
   }, [exploitation])
 
   return (

--- a/src/components/form/exploitation-edition-form.js
+++ b/src/components/form/exploitation-edition-form.js
@@ -33,12 +33,13 @@ const ExploitationEditionForm = ({
     setValidationErrors([])
 
     if (Object.keys(payload).length === 0) {
-      router.push(`/prelevements/${exploitation.id_point}`)
+      router.push(`/prelevements/${exploitation.point}`)
+      return
     }
 
     try {
       const cleanedPayload = emptyStringToNull(payload)
-      const response = await updateExploitation(exploitation.id_exploitation, cleanedPayload)
+      const response = await updateExploitation(exploitation._id, cleanedPayload)
 
       if (response.code === 400) {
         if (response.validationErrors) {
@@ -48,7 +49,7 @@ const ExploitationEditionForm = ({
         }
       } else {
         // TODO : Rediriger vers la page exploitation quand elle sera terminée
-        router.push(`/prelevements/${exploitation.id_point}`)
+        router.push(`/prelevements/${exploitation.point}`)
       }
     } catch (error) {
       setError(error.message)
@@ -59,8 +60,8 @@ const ExploitationEditionForm = ({
     setError(null)
 
     try {
-      await deleteExploitation(exploitation.id_exploitation)
-      router.push(`/prelevements/${exploitation.id_point}`)
+      await deleteExploitation(exploitation._id)
+      router.push(`/prelevements/${exploitation.point}`)
     } catch (error) {
       setError(error.message)
     }

--- a/src/components/form/exploitation-form.js
+++ b/src/components/form/exploitation-form.js
@@ -62,8 +62,8 @@ const ExploitationForm = ({exploitation, points, preleveurs, setExploitation, id
   const [isStatutAbandonnee, setIsStatutAbandonnee] = useState(exploitation?.statut === 'Abandonnée')
   const initialUsages = exploitation?.usages || []
   const [usages, setUsages] = useState(exploitation?.usages || [])
-  const defaultPoint = points.find(p => p.id_point === (exploitation?.id_point || idPoint))
-  const defaultPreleveur = preleveurs.find(p => p.id_preleveur === exploitation?.id_preleveur)
+  const defaultPoint = points.find(p => p._id === (exploitation?.point || idPoint))
+  const defaultPreleveur = preleveurs.find(p => p._id === exploitation?.preleveur)
 
   const handleUsages = (e, usage) => {
     setUsages(prev => {
@@ -108,7 +108,7 @@ const ExploitationForm = ({exploitation, points, preleveurs, setExploitation, id
                 type={type}
                 onChange={(e, value) => setExploitation(prev => ({
                   ...prev,
-                  id_point: value?.point?.id_point
+                  point: value?.point?._id
                 }))}
               />
             )}
@@ -124,14 +124,16 @@ const ExploitationForm = ({exploitation, points, preleveurs, setExploitation, id
                   preleveur,
                   label: displayPreleveur(preleveur)
                 }))}
-                defaultValue={displayPreleveur(defaultPreleveur)}
+                defaultValue={defaultPreleveur
+                  ? displayPreleveur(defaultPreleveur)
+                  : null}
                 className={className}
                 id={id}
                 placeholder={placeholder}
                 type={type}
                 onChange={(e, value) => setExploitation(prev => ({
                   ...prev,
-                  id_preleveur: value?.preleveur?.id_preleveur
+                  preleveur: value?.preleveur?._id
                 }))}
               />
             )}

--- a/src/components/form/point-edition-form.js
+++ b/src/components/form/point-edition-form.js
@@ -36,9 +36,14 @@ const PointEditionForm = ({
     setError(null)
     setValidationErrors([])
 
+    if (Object.keys(payload).length === 0) {
+      router.push(`/prelevements?point-prelevement=${point._id}`)
+      return
+    }
+
     try {
       const cleanedPayload = emptyStringToNull(payload)
-      const response = await editPointPrelevement(point.id_point, cleanedPayload)
+      const response = await editPointPrelevement(point._id, cleanedPayload)
 
       if (response.code === 400) {
         if (response.validationErrors) {
@@ -47,7 +52,7 @@ const PointEditionForm = ({
           setError(response.message)
         }
       } else {
-        router.push(`/prelevements?point-prelevement=${response.id_point}`)
+        router.push(`/prelevements?point-prelevement=${response._id}`)
       }
     } catch (error) {
       setError(error.message)
@@ -58,7 +63,7 @@ const PointEditionForm = ({
     setError(null)
 
     try {
-      await deletePointPrelevement(point.id_point)
+      await deletePointPrelevement(point._id)
       router.push('/prelevements')
     } catch (error) {
       setError(error.message)

--- a/src/components/form/preleveur-creation-form.js
+++ b/src/components/form/preleveur-creation-form.js
@@ -86,7 +86,7 @@ const PreleveurCreationForm = () => {
           setError(response.message)
         }
       } else {
-        router.push(`/preleveurs/${response.id_preleveur}`)
+        router.push(`/preleveurs/${response._id}`)
       }
     } catch (error) {
       setError(error.message)

--- a/src/components/form/preleveur-edition-form.js
+++ b/src/components/form/preleveur-edition-form.js
@@ -34,7 +34,7 @@ const PreleveurEditionForm = ({preleveur}) => {
     setValidationErrors(null)
 
     if (Object.keys(payload).length === 0) {
-      router.push(`/preleveurs/${preleveur.id_preleveur}`)
+      router.push(`/preleveurs/${preleveur._id}`)
 
       return
     }
@@ -57,7 +57,7 @@ const PreleveurEditionForm = ({preleveur}) => {
 
     try {
       const cleanedPreleveur = emptyStringToNull(payload)
-      const response = await updatePreleveur(preleveur.id_preleveur, cleanedPreleveur)
+      const response = await updatePreleveur(preleveur._id, cleanedPreleveur)
 
       if (response.code === 400) {
         if (response.validationErrors) {
@@ -66,7 +66,7 @@ const PreleveurEditionForm = ({preleveur}) => {
           setError(response.message)
         }
       } else {
-        router.push(`/preleveurs/${response.id_preleveur}`)
+        router.push(`/preleveurs/${response._id}`)
       }
     } catch (error) {
       setError(error.message)
@@ -77,7 +77,7 @@ const PreleveurEditionForm = ({preleveur}) => {
     setError(null)
 
     try {
-      const response = await deletePreleveur(preleveur.id_preleveur)
+      const response = await deletePreleveur(preleveur._id)
 
       if (response.code) {
         setIsDialogOpen(false)

--- a/src/components/form/preleveur-moral-form.js
+++ b/src/components/form/preleveur-moral-form.js
@@ -53,7 +53,7 @@ const PreleveurMoralForm = ({preleveur, setPreleveur}) => {
           label='Civilité du contact'
           placeholder='Choisir la civilité'
           nativeSelectProps={{
-            value: preleveur?.civilite || '',
+            defaultValue: preleveur?.civilite || '',
             onChange: e => setPreleveur(prev => ({...prev, civilite: e.target.value}))
           }}
           options={[
@@ -66,7 +66,7 @@ const PreleveurMoralForm = ({preleveur, setPreleveur}) => {
           label='Nom du contact *'
           nativeInputProps={{
             placeholder: 'Entrer le nom',
-            value: preleveur?.nom || '',
+            defaultValue: preleveur?.nom || '',
             onChange: e => setPreleveur(prev => ({...prev, nom: e.target.value}))
           }}
         />
@@ -74,7 +74,7 @@ const PreleveurMoralForm = ({preleveur, setPreleveur}) => {
           label='Prénom du contact *'
           nativeInputProps={{
             placeholder: 'Entrer le prénom',
-            value: preleveur?.prenom || '',
+            defaultValue: preleveur?.prenom || '',
             onChange: e => setPreleveur(prev => ({...prev, prenom: e.target.value}))
           }}
         />
@@ -83,7 +83,7 @@ const PreleveurMoralForm = ({preleveur, setPreleveur}) => {
         label='Adresse email du contact *'
         nativeInputProps={{
           placeholder: 'Entrer l’adresse email de contact',
-          value: preleveur?.email || '',
+          defaultValue: preleveur?.email || '',
           onChange: e => setPreleveur(prev => ({...prev, email: e.target.value}))
         }}
       />

--- a/src/components/map/point.js
+++ b/src/components/map/point.js
@@ -8,7 +8,7 @@ import {getUsageColor, getTypeMilieuColor} from '@/lib/points-prelevement.js'
 
 const Point = ({point, index}) => (
   <ListItem
-    key={point.id_point}
+    key={point._id}
     sx={{
       backgroundColor: index % 2 === 0 ? fr.colors.decisions.background.default.grey.default : fr.colors.decisions.background.alt.blueFrance.default,
       justifyContent: 'space-between',
@@ -32,7 +32,7 @@ const Point = ({point, index}) => (
       )}
       {point.usages && point.usages.map(usage => (
         <Chip
-          key={`${point.id_point}-${usage}`}
+          key={`${point._id}-${usage}`}
           label={usage}
           sx={{
             backgroundColor: getUsageColor(usage).background,

--- a/src/components/prelevements/point-exploitations.js
+++ b/src/components/prelevements/point-exploitations.js
@@ -42,6 +42,10 @@ const LabelValue = ({label, value}) => {
 }
 
 function getPreleveurInfo(preleveur) {
+  if (!preleveur) {
+    return null
+  }
+
   if (preleveur.nom) {
     return `${preleveur.civilite || ''} ${preleveur.nom} ${preleveur.prenom || ''}`
   }
@@ -114,7 +118,7 @@ const PointExploitations = ({pointPrelevement, exploitations}) => {
           priority='secondary'
           iconId='fr-icon-add-line'
           linkProps={{
-            href: `/exploitations/new?idPoint=${pointPrelevement.id_point}`
+            href: `/exploitations/new?idPoint=${pointPrelevement._id}`
           }}
         >
           Créer une exploitation
@@ -127,13 +131,13 @@ const PointExploitations = ({pointPrelevement, exploitations}) => {
             dateSignature: new Date(document.date_signature)
           }))
           const orderedDocuments = orderBy(documents, ['dateSignature'], ['desc'])
-          const preleveur = pointPrelevement.preleveurs.find(b => b.id_preleveur === exploitation.id_preleveur)
+          const preleveur = pointPrelevement.preleveurs.find(p => p._id === exploitation.preleveur)
 
           return (
             <Accordion
-              key={exploitation.id_exploitation}
-              expanded={expanded === exploitation.id_exploitation}
-              onChange={handleChange(exploitation.id_exploitation)}
+              key={exploitation._id}
+              expanded={expanded === exploitation._id}
+              onChange={handleChange(exploitation._id)}
             >
               <AccordionSummary expandIcon={<ExpandMore />}>
                 <div className='flex gap-1 sm:gap-5 flex-col sm:flex-row justify-between items-start sm:items-center w-full'>
@@ -160,7 +164,7 @@ const PointExploitations = ({pointPrelevement, exploitations}) => {
                     priority='secondary'
                     size='small'
                     iconId='fr-icon-edit-line'
-                    onClick={() => router.push(`/exploitations/${exploitation.id_exploitation}/edit`)}
+                    onClick={() => router.push(`/exploitations/${exploitation._id}/edit`)}
                   >
                     Éditer
                   </Button>
@@ -169,7 +173,7 @@ const PointExploitations = ({pointPrelevement, exploitations}) => {
                   <Alert severity='error' description={error} />
                 )}
                 {expanded === exploitation.id_exploitation && (
-                  <VolumesChart idExploitation={exploitation.id_exploitation} />
+                  <VolumesChart idExploitation={exploitation._id} />
                 )}
                 <Grid2
                   container

--- a/src/components/prelevements/point-identification.js
+++ b/src/components/prelevements/point-identification.js
@@ -17,7 +17,7 @@ const LinkWithIcon = ({label, href}) => (
 )
 
 const PointIdentification = ({pointPrelevement, lienBss, lienBnpe}) => {
-  const {id_point: idPoint, nom} = pointPrelevement
+  const {_id, id_point: idPoint, nom} = pointPrelevement
 
   return (
     <div className='flex flex-col gap-4'>
@@ -34,7 +34,7 @@ const PointIdentification = ({pointPrelevement, lienBss, lienBnpe}) => {
             priority='secondary'
             iconId='fr-icon-edit-line'
             linkProps={{
-              href: `/prelevements/${idPoint}/edit`
+              href: `/prelevements/${_id}/edit`
             }}
           >
             Éditer

--- a/src/components/preleveurs/preleveur.js
+++ b/src/components/preleveurs/preleveur.js
@@ -9,7 +9,7 @@ import Link from 'next/link'
 import {getUsagesColors} from '@/components/map/legend-colors.js'
 
 const Preleveur = ({preleveur, index}) => (
-  <Link href={`preleveurs/${preleveur.id_preleveur}`}>
+  <Link href={`preleveurs/${preleveur._id}`}>
     <Box
       key={preleveur.id_preleveur}
       className='fr-p-2w flex justify-between items-top flex-wrap'

--- a/src/lib/points-prelevement.js
+++ b/src/lib/points-prelevement.js
@@ -59,7 +59,7 @@ export function createPointPrelevementFeatures(points) {
     features: points.map(point => ({
       type: 'Feature',
       geometry: point.geom,
-      id: point.id_point,
+      id: point._id,
       properties: {
         ...point,
         textOffset: [0, 1.5 + (0.07 * Math.min(point.nom?.length || 0, 50))]

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -31,7 +31,7 @@ export function getPointsPrelevementURL() {
 }
 
 export function getPointPrelevementURL(point) {
-  return `/prelevements/${point.id_point}`
+  return `/prelevements/${point._id}`
 }
 
 export function getDocumentURL(document) {


### PR DESCRIPTION
Cette PR modifie l'utilisation des identifiants, en remplaçant les références `id_point`, `id_preleveur` et `id_exploitation` par leur identifiant en base de données (`_id`).

> [!WARNING]
> Il faut fusionner ce code en même temps que la PR backend