### PR TITLE
Affiche les `id_*` dans les URLs à la place des `_id` & corrections formulaires

### DIFF
--- a/src/app/preleveurs/[id]/page.js
+++ b/src/app/preleveurs/[id]/page.js
@@ -34,7 +34,7 @@ const Page = async ({params}) => {
                 priority='secondary'
                 iconId='fr-icon-edit-line'
                 linkProps={{
-                  href: `/preleveurs/${preleveur._id}/edit`
+                  href: `/preleveurs/${preleveur.id_preleveur}/edit`
                 }}
               >
                 Éditer
@@ -75,7 +75,7 @@ const Page = async ({params}) => {
           {points && points.length > 0 ? (
             points.map(point => (
               <div key={point._id}>
-                <Link href={`/prelevements/${point._id}`}>
+                <Link href={`/prelevements/${point.id_point}`}>
                   {point.id_point} - {point.nom}
                 </Link>
               </div>

--- a/src/components/form/exploitation-edition-form.js
+++ b/src/components/form/exploitation-edition-form.js
@@ -60,7 +60,14 @@ const ExploitationEditionForm = ({
     setError(null)
 
     try {
-      await deleteExploitation(exploitation._id)
+      const response = await deleteExploitation(exploitation._id)
+
+      if (response.code) {
+        setIsDialogOpen(false)
+        setError(response.message)
+        return
+      }
+
       router.push(`/prelevements/${exploitation.point}`)
     } catch (error) {
       setError(error.message)

--- a/src/components/form/point-edition-form.js
+++ b/src/components/form/point-edition-form.js
@@ -37,7 +37,7 @@ const PointEditionForm = ({
     setValidationErrors([])
 
     if (Object.keys(payload).length === 0) {
-      router.push(`/prelevements?point-prelevement=${point._id}`)
+      router.push(`/prelevements?point-prelevement=${point.id_point}`)
       return
     }
 
@@ -52,7 +52,7 @@ const PointEditionForm = ({
           setError(response.message)
         }
       } else {
-        router.push(`/prelevements?point-prelevement=${response._id}`)
+        router.push(`/prelevements?point-prelevement=${response.id_point}`)
       }
     } catch (error) {
       setError(error.message)

--- a/src/components/form/point-edition-form.js
+++ b/src/components/form/point-edition-form.js
@@ -63,7 +63,14 @@ const PointEditionForm = ({
     setError(null)
 
     try {
-      await deletePointPrelevement(point._id)
+      const response = await deletePointPrelevement(point._id)
+
+      if (response.code) {
+        setIsDialogOpen(false)
+        setError(response.message)
+        return
+      }
+
       router.push('/prelevements')
     } catch (error) {
       setError(error.message)

--- a/src/components/form/preleveur-creation-form.js
+++ b/src/components/form/preleveur-creation-form.js
@@ -86,7 +86,7 @@ const PreleveurCreationForm = () => {
           setError(response.message)
         }
       } else {
-        router.push(`/preleveurs/${response._id}`)
+        router.push(`/preleveurs/${response.id_preleveur}`)
       }
     } catch (error) {
       setError(error.message)

--- a/src/components/form/preleveur-edition-form.js
+++ b/src/components/form/preleveur-edition-form.js
@@ -34,7 +34,7 @@ const PreleveurEditionForm = ({preleveur}) => {
     setValidationErrors(null)
 
     if (Object.keys(payload).length === 0) {
-      router.push(`/preleveurs/${preleveur._id}`)
+      router.push(`/preleveurs/${preleveur.id_preleveur}`)
 
       return
     }
@@ -57,7 +57,7 @@ const PreleveurEditionForm = ({preleveur}) => {
 
     try {
       const cleanedPreleveur = emptyStringToNull(payload)
-      const response = await updatePreleveur(preleveur._id, cleanedPreleveur)
+      const response = await updatePreleveur(preleveur.id_preleveur, cleanedPreleveur)
 
       if (response.code === 400) {
         if (response.validationErrors) {
@@ -66,7 +66,7 @@ const PreleveurEditionForm = ({preleveur}) => {
           setError(response.message)
         }
       } else {
-        router.push(`/preleveurs/${response._id}`)
+        router.push(`/preleveurs/${response.id_preleveur}`)
       }
     } catch (error) {
       setError(error.message)

--- a/src/components/form/preleveur-moral-form.js
+++ b/src/components/form/preleveur-moral-form.js
@@ -34,7 +34,7 @@ const PreleveurMoralForm = ({preleveur, setPreleveur}) => {
           label='Code SIREN'
           nativeInputProps={{
             placeholder: 'Entrer le code SIREN',
-            value: preleveur?.code_siren || '',
+            defaultValue: preleveur?.code_siren || '',
             onChange: e => setPreleveur(prev => ({...prev, code_siren: e.target.value}))
           }}
         />
@@ -44,7 +44,7 @@ const PreleveurMoralForm = ({preleveur, setPreleveur}) => {
         hintText='Nom officiel de l’entreprise'
         nativeInputProps={{
           placeholder: 'Entrer la raison sociale',
-          value: preleveur?.raison_sociale || '',
+          defaultValue: preleveur?.raison_sociale || '',
           onChange: e => setPreleveur(prev => ({...prev, raison_sociale: e.target.value}))
         }}
       />

--- a/src/components/form/preleveur-physique-form.js
+++ b/src/components/form/preleveur-physique-form.js
@@ -30,7 +30,7 @@ const PreleveurPhysiqueForm = ({preleveur, setPreleveur}) => {
           placeholder='Choisir la civilité'
           nativeSelectProps={{
             placeholder: 'Choisir la civilité',
-            value: preleveur?.civilite || '',
+            defaultValue: preleveur?.civilite || '',
             onChange: e => setPreleveur(prev => ({...prev, civilite: e.target.value}))
           }}
           options={[
@@ -43,7 +43,7 @@ const PreleveurPhysiqueForm = ({preleveur, setPreleveur}) => {
           label='Nom *'
           nativeInputProps={{
             placeholder: 'Entrer le nom',
-            value: preleveur?.nom || '',
+            defaultValue: preleveur?.nom || '',
             onChange: e => setPreleveur(prev => ({...prev, nom: e.target.value}))
           }}
         />
@@ -51,7 +51,7 @@ const PreleveurPhysiqueForm = ({preleveur, setPreleveur}) => {
           label='Prénom *'
           nativeInputProps={{
             placeholder: 'Entrer le prénom',
-            value: preleveur?.prenom || '',
+            defaultValue: preleveur?.prenom || '',
             onChange: e => setPreleveur(prev => ({...prev, prenom: e.target.value}))
           }}
         />
@@ -59,7 +59,7 @@ const PreleveurPhysiqueForm = ({preleveur, setPreleveur}) => {
       <Input
         label='Adresse e-mail *'
         nativeInputProps={{
-          value: preleveur?.email || '',
+          defaultValue: preleveur?.email || '',
           placeholder: 'Entrez l’adresse e-mail de contact',
           onChange: e => setPreleveur(prev => ({...prev, email: e.target.value}))
         }}

--- a/src/components/prelevements/point-exploitations.js
+++ b/src/components/prelevements/point-exploitations.js
@@ -209,7 +209,8 @@ const PointExploitations = ({pointPrelevement, exploitations}) => {
               </AccordionDetails>
             </Accordion>
           )
-        }) : (
+        })}
+        {exploitationsWithVolumes.length === 0 && !isLoading && (
           <div>
             <i>Pas d’exploitation</i>
           </div>

--- a/src/components/prelevements/point-exploitations.js
+++ b/src/components/prelevements/point-exploitations.js
@@ -118,14 +118,14 @@ const PointExploitations = ({pointPrelevement, exploitations}) => {
           priority='secondary'
           iconId='fr-icon-add-line'
           linkProps={{
-            href: `/exploitations/new?idPoint=${pointPrelevement._id}`
+            href: `/exploitations/new?idPoint=${pointPrelevement.id_point}`
           }}
         >
           Créer une exploitation
         </Button>
       </div>
       <div>
-        {!isLoading && exploitationsWithVolumes.length > 0 ? exploitationsWithVolumes.map(exploitation => {
+        {!isLoading && exploitationsWithVolumes.length > 0 && exploitationsWithVolumes.map(exploitation => {
           const documents = exploitation.documents.map(document => ({
             ...document,
             dateSignature: new Date(document.date_signature)
@@ -136,8 +136,8 @@ const PointExploitations = ({pointPrelevement, exploitations}) => {
           return (
             <Accordion
               key={exploitation._id}
-              expanded={expanded === exploitation._id}
-              onChange={handleChange(exploitation._id)}
+              expanded={expanded === exploitation.id_exploitation}
+              onChange={handleChange(exploitation.id_exploitation)}
             >
               <AccordionSummary expandIcon={<ExpandMore />}>
                 <div className='flex gap-1 sm:gap-5 flex-col sm:flex-row justify-between items-start sm:items-center w-full'>
@@ -164,7 +164,7 @@ const PointExploitations = ({pointPrelevement, exploitations}) => {
                     priority='secondary'
                     size='small'
                     iconId='fr-icon-edit-line'
-                    onClick={() => router.push(`/exploitations/${exploitation._id}/edit`)}
+                    onClick={() => router.push(`/exploitations/${exploitation.id_exploitation}/edit`)}
                   >
                     Éditer
                   </Button>
@@ -173,7 +173,7 @@ const PointExploitations = ({pointPrelevement, exploitations}) => {
                   <Alert severity='error' description={error} />
                 )}
                 {expanded === exploitation.id_exploitation && (
-                  <VolumesChart idExploitation={exploitation._id} />
+                  <VolumesChart idExploitation={exploitation.id_exploitation} />
                 )}
                 <Grid2
                   container

--- a/src/components/prelevements/point-identification.js
+++ b/src/components/prelevements/point-identification.js
@@ -17,7 +17,7 @@ const LinkWithIcon = ({label, href}) => (
 )
 
 const PointIdentification = ({pointPrelevement, lienBss, lienBnpe}) => {
-  const {_id, id_point: idPoint, nom} = pointPrelevement
+  const {id_point: idPoint, nom} = pointPrelevement
 
   return (
     <div className='flex flex-col gap-4'>
@@ -34,7 +34,7 @@ const PointIdentification = ({pointPrelevement, lienBss, lienBnpe}) => {
             priority='secondary'
             iconId='fr-icon-edit-line'
             linkProps={{
-              href: `/prelevements/${_id}/edit`
+              href: `/prelevements/${idPoint}/edit`
             }}
           >
             Éditer

--- a/src/components/preleveurs/preleveur.js
+++ b/src/components/preleveurs/preleveur.js
@@ -9,7 +9,7 @@ import Link from 'next/link'
 import {getUsagesColors} from '@/components/map/legend-colors.js'
 
 const Preleveur = ({preleveur, index}) => (
-  <Link href={`preleveurs/${preleveur._id}`}>
+  <Link href={`preleveurs/${preleveur.id_preleveur}`}>
     <Box
       key={preleveur.id_preleveur}
       className='fr-p-2w flex justify-between items-top flex-wrap'

--- a/src/components/regles.js
+++ b/src/components/regles.js
@@ -3,6 +3,7 @@
 import {Button} from '@codegouvfr/react-dsfr/Button'
 import {Box} from '@mui/material'
 import {Grid} from '@mui/system'
+import {uniqueId} from 'lodash-es'
 
 import Regle from '@/components/regle.js'
 import {downloadCsv} from '@/lib/export-csv.js'
@@ -37,7 +38,7 @@ const Regles = ({regles, documents}) => {
 
           return (
             <Regle
-              key={regle.id_regle}
+              key={uniqueId()}
               regle={regle}
               document={document}
             />

--- a/src/lib/points-prelevement.js
+++ b/src/lib/points-prelevement.js
@@ -59,7 +59,7 @@ export function createPointPrelevementFeatures(points) {
     features: points.map(point => ({
       type: 'Feature',
       geometry: point.geom,
-      id: point._id,
+      id: point.id_point,
       properties: {
         ...point,
         textOffset: [0, 1.5 + (0.07 * Math.min(point.nom?.length || 0, 50))]

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -13,7 +13,7 @@ export function getDossiersURL() {
 }
 
 export function getPreleveurURL(preleveur) {
-  return `/preleveurs/${preleveur._id}`
+  return `/preleveurs/${preleveur.id_preleveur}`
 }
 
 export function getNewPreleveurURL(params) {
@@ -31,7 +31,7 @@ export function getPointsPrelevementURL() {
 }
 
 export function getPointPrelevementURL(point) {
-  return `/prelevements/${point._id}`
+  return `/prelevements/${point.id_point}`
 }
 
 export function getDocumentURL(document) {


### PR DESCRIPTION
Cette PR propose d'afficher les `id_*` des points, exploitations et préleveurs à la place des `_id`, moins identifiables, dans les URLs.

Elle corrige également quelques bugs dans les formulaires.

- Modification des URLs
- Correction d'une erreur de clé unique sur le composant `Regle`
- Ajout de la gestion des erreurs sur la suppression d'un point ou d'une exploitation
- Corrige le formulaire d'édition du préleveur

> [!warning]
> Ces modifications nécessitent [les modifications sur les `resolvers`](https://github.com/MTES-MCT/prelevements-deau-api/pull/74) 