### PR TITLE
Style provider MuiDsfr pour Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,7 @@
-import "@codegouvfr/react-dsfr/main.css";
-import { startReactDsfr } from "@codegouvfr/react-dsfr/spa";
-import { MuiDsfrThemeProvider } from "@codegouvfr/react-dsfr/mui";
-import "../src/app/globals.css";
+import "@codegouvfr/react-dsfr/main.css"
+import { startReactDsfr } from "@codegouvfr/react-dsfr/spa"
+import { MuiDsfrThemeProvider } from "@codegouvfr/react-dsfr/mui"
+import "../src/app/globals.css"
 
 startReactDsfr({
     defaultColorScheme: "light",

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,7 @@
-import "@codegouvfr/react-dsfr/main.css"
-import {startReactDsfr} from "@codegouvfr/react-dsfr/spa"
-import {MuiDsfrThemeProvider} from "@codegouvfr/react-dsfr/mui"
-import "../src/app/globals.css"
+import '@codegouvfr/react-dsfr/main.css'
+import {startReactDsfr} from '@codegouvfr/react-dsfr/spa'
+import {MuiDsfrThemeProvider} from '@codegouvfr/react-dsfr/mui'
+import '../src/app/globals.css'
 
 startReactDsfr({
     defaultColorScheme: "light",
@@ -18,12 +18,12 @@ const preview = {
         },
     },
     decorators: [
-        (Story) => (
+        Story => (
             <MuiDsfrThemeProvider>
                 <Story />
             </MuiDsfrThemeProvider>
         ),
     ],
-};
+}
 
-export default preview;
+export default preview

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,6 @@
 import "@codegouvfr/react-dsfr/main.css"
-import { startReactDsfr } from "@codegouvfr/react-dsfr/spa"
-import { MuiDsfrThemeProvider } from "@codegouvfr/react-dsfr/mui"
+import {startReactDsfr} from "@codegouvfr/react-dsfr/spa"
+import {MuiDsfrThemeProvider} from "@codegouvfr/react-dsfr/mui"
 import "../src/app/globals.css"
 
 startReactDsfr({

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,7 @@
-import "@codegouvfr/react-dsfr/main.css"
-import {startReactDsfr} from "@codegouvfr/react-dsfr/spa"
-import '../src/app/globals.css'
+import "@codegouvfr/react-dsfr/main.css";
+import { startReactDsfr } from "@codegouvfr/react-dsfr/spa";
+import { MuiDsfrThemeProvider } from "@codegouvfr/react-dsfr/mui";
+import "../src/app/globals.css";
 
 startReactDsfr({
     defaultColorScheme: "light",
@@ -16,6 +17,13 @@ const preview = {
             },
         },
     },
-}
+    decorators: [
+        (Story) => (
+            <MuiDsfrThemeProvider>
+                <Story />
+            </MuiDsfrThemeProvider>
+        ),
+    ],
+};
 
-export default preview
+export default preview;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,25 +5,25 @@ import '../src/app/globals.css'
 
 startReactDsfr({
     defaultColorScheme: 'light',
-    useLang: () => 'fr',
-});
+    useLang: () => 'fr'
+})
 
 const preview = {
     parameters: {
         controls: {
             matchers: {
                 color: /(background|color)$/i,
-                date: /Date$/i,
-            },
-        },
+                date: /Date$/i
+            }
+        }
     },
     decorators: [
         Story => (
             <MuiDsfrThemeProvider>
                 <Story />
             </MuiDsfrThemeProvider>
-        ),
-    ],
+        )
+    ]
 }
 
 export default preview

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,8 +4,8 @@ import {MuiDsfrThemeProvider} from '@codegouvfr/react-dsfr/mui'
 import '../src/app/globals.css'
 
 startReactDsfr({
-    defaultColorScheme: "light",
-    useLang: () => "fr",
+    defaultColorScheme: 'light',
+    useLang: () => 'fr',
 });
 
 const preview = {


### PR DESCRIPTION
Cette pull request met à jour la configuration de Storybook afin d’améliorer l’intégration du thème et la cohérence du code. Les changements les plus importants sont regroupés ci-dessous :  

**Intégration du thème :**

- Ajout du `MuiDsfrThemeProvider` depuis `@codegouvfr/react-dsfr/mui` et encapsulation de toutes les stories avec ce provider via un décorateur Storybook, permettant une utilisation cohérente des thèmes DSFR et MUI dans l’ensemble des composants.
