### PR TITLE
Ajeout de la page `/exploitations/{id}`

### DIFF
--- a/src/app/exploitations/[id]/page.js
+++ b/src/app/exploitations/[id]/page.js
@@ -1,0 +1,97 @@
+import {fr} from '@codegouvfr/react-dsfr'
+import Tag from '@codegouvfr/react-dsfr/Tag'
+import {WavesOutlined} from '@mui/icons-material'
+import {Divider, Grid2, Typography} from '@mui/material'
+import Link from 'next/link'
+
+import {
+  getExploitation,
+  getPointPrelevement,
+  getPreleveur
+} from '@/app/api/points-prelevement.js'
+import Document from '@/components/document.js'
+import ExploitationItem from '@/components/exploitations/exploitation-item.js'
+import Regles from '@/components/regles.js'
+import {StartDsfrOnHydration} from '@/dsfr-bootstrap/index.js'
+import {displayPreleveur} from '@/utils/preleveurs.js'
+
+const Page = async ({params}) => {
+  const {id} = await params
+
+  const exploitation = await getExploitation(id)
+  const point = await getPointPrelevement(exploitation.point)
+  const preleveur = await getPreleveur(exploitation.preleveur)
+
+  return (
+    <>
+      <StartDsfrOnHydration />
+      <div className='fr-container mt-4'>
+        <ExploitationItem exploitation={exploitation}>
+          <div className='fr-mb-2w'>
+            <span
+              className='fr-icon-user-line pr-2'
+              aria-hidden='true'
+              style={{
+                color: fr.colors.decisions.text.actionHigh.blueFrance.default
+              }}
+            />
+            <Link href={`/preleveurs/${preleveur.id_preleveur}`}>
+              {displayPreleveur(preleveur)}
+            </Link>
+          </div>
+          <div>
+            <span
+              className='fr-icon-map-pin-2-line pr-2'
+              aria-hidden='true'
+              style={{
+                color: fr.colors.decisions.text.actionHigh.blueFrance.default
+              }}
+            />
+            <Link href={`/prelevements/${point.id_point}`}>
+              {point.nom}
+            </Link>
+            <Tag
+              small
+              severity='info'
+              className='pl-2 ml-3'
+              style={{
+                backgroundColor: fr.colors.decisions.background.actionLow.blueFrance.default,
+                color: fr.colors.decisions.text.actionHigh.blueFrance.default
+              }}
+            >
+              <span className='pr-2'>
+                <WavesOutlined />
+              </span>
+              {point.type_milieu}
+            </Tag>
+          </div>
+        </ExploitationItem>
+
+        <div className='fr-h6 fr-mt-5w'>Ressources</div>
+        <Grid2>
+          <Divider sx={{m: 2}} textAlign='left'>
+            Documents
+          </Divider>
+          {exploitation?.documents?.map(document => (
+            <Document key={document.id_document} document={document} />
+          ))}
+        </Grid2>
+        <Grid2 className='fr-mb-5w'>
+          <Divider sx={{m: 2}} textAlign='left'>
+            Règles
+          </Divider>
+          {exploitation.regles.length > 0 ? (
+            <Regles
+              regles={exploitation.regles}
+              documents={exploitation.documents}
+            />
+          ) : (
+            <Typography>Aucune règle</Typography>
+          )}
+        </Grid2>
+      </div>
+    </>
+  )
+}
+
+export default Page

--- a/src/components/exploitations/exploitation-item.js
+++ b/src/components/exploitations/exploitation-item.js
@@ -1,0 +1,54 @@
+import {
+  AgricultureOutlined,
+  CalendarMonthOutlined,
+  LocalDrinkOutlined,
+  LocalShippingOutlined,
+  InterestsOutlined,
+  LiquorOutlined,
+  BoltOutlined,
+  FactoryOutlined,
+  DeviceThermostatOutlined,
+  EditOffOutlined
+} from '@mui/icons-material'
+
+import EntityHeader from '@/components/ui/EntityHeader/index.js'
+import {formatDateRange} from '@/lib/format-date.js'
+
+const exploitationUsages = {
+  'Eau potable': LocalDrinkOutlined,
+  Agriculture: AgricultureOutlined,
+  Autre: InterestsOutlined,
+  'Camion citerne': LocalShippingOutlined,
+  'Eau embouteillée': LiquorOutlined,
+  Hydroélectricité: BoltOutlined,
+  Industrie: FactoryOutlined,
+  'non-renseignée': EditOffOutlined,
+  Thermalisme: DeviceThermostatOutlined
+}
+
+const ExploitationItem = ({exploitation, children}) => (
+  <EntityHeader
+    title={`Exploitation - ${exploitation.id_exploitation}`}
+    tags={[{label: exploitation.statut, severity: 'info'}]}
+    metas={[
+      {
+        icon: CalendarMonthOutlined,
+        content: formatDateRange(exploitation.date_debut, exploitation.date_fin)
+      }
+    ]}
+    hrefButtons={[
+      {
+        label: 'Éditer',
+        icon: 'fr-icon-edit-line',
+        href: `/exploitations/${exploitation.id_exploitation}/edit`
+      }
+    ]}
+    rightBadges={exploitation.usages.map(usage => (
+      {label: usage, icon: exploitationUsages[usage]}
+    ))}
+  >
+    {children}
+  </EntityHeader>
+)
+
+export default ExploitationItem

--- a/src/components/form/exploitation-form.js
+++ b/src/components/form/exploitation-form.js
@@ -13,29 +13,12 @@ import ReglesForm from './regles-form.js'
 
 import SearchAutocomplete from '@/components/form/search-autocomplete.js'
 import AccordionCentered from '@/components/ui/accordion-centered.js'
+import {displayPreleveur} from '@/utils/preleveurs.js'
 
 const DynamicCheckbox = dynamic(
   () => import('@codegouvfr/react-dsfr/Checkbox'),
   {ssr: false}
 )
-
-function displayPreleveur(preleveur) {
-  if (!preleveur) {
-    return
-  }
-
-  if (preleveur.nom) {
-    return `${preleveur.civilite || ''} ${preleveur.nom} ${preleveur.prenom}`
-  }
-
-  if (preleveur.sigle) {
-    return preleveur.sigle
-  }
-
-  if (preleveur.raison_sociale) {
-    return preleveur.raison_sociale
-  }
-}
 
 const statutsExploitation = [
   'En activité',

--- a/src/utils/preleveurs.js
+++ b/src/utils/preleveurs.js
@@ -1,0 +1,17 @@
+export function displayPreleveur(preleveur) {
+  if (!preleveur) {
+    return
+  }
+
+  if (preleveur.sigle) {
+    return preleveur.sigle
+  }
+
+  if (preleveur.raison_sociale) {
+    return preleveur.raison_sociale
+  }
+
+  if (preleveur.nom) {
+    return `${preleveur.civilite || ''} ${preleveur.nom} ${preleveur.prenom}`
+  }
+}


### PR DESCRIPTION
Cette PR ajoute une page `/exploitations/{id}` afin d'afficher les détails d'une exploitation.

## Capture : 

<img width="1325" height="1026" alt="image" src="https://github.com/user-attachments/assets/b612eb0d-fe03-4816-891c-aa4a085f2d01" />
