### PR TITLE
Refactorisation du composant UI `PrelevementsHistory`

### DIFF
--- a/src/components/ui/PrelevementsHistory/index.js
+++ b/src/components/ui/PrelevementsHistory/index.js
@@ -6,66 +6,69 @@ import ParameterTrendChart from '@/components/declarations/dossier/prelevements/
 import PrelevementsCalendar from '@/components/declarations/prelevements-calendar.js'
 
 const PrelevementsHistory = ({
-  dailyItems,
-  intervalItems,
-  dailyAlert,
-  dateAlert,
-  calendarData,
-  chartData,
-  connectNulls
+  dailyParametersAlert,
+  calendarAlert,
+  historyData,
+  isTrendChartIgnoringNulls
 }) => (
   <Box className='flex flex-col gap-6'>
     <Typography variant='h6' component='h2'>
       Historique des prélèvements
     </Typography>
 
-    <Box className='flex flex-col gap-4'>
-      <Divider textAlign='left'>Données par pas de temps</Divider>
+    {historyData ? (
+      <>
+        {(historyData.dailyParameters || historyData.fifteenMinutesParameters) && (
+          <Box className='flex flex-col gap-4'>
+            <Divider textAlign='left'>Données par pas de temps</Divider>
 
-      <Box className='flex flex-col gap-2'>
-        {dailyItems && (
-          <Box className='flex flex-wrap gap-1 items-center'>
-            Journalier : {dailyItems.map(param => (
-              <Tag key={param.paramIndex} sx={{m: 1}}>
-                {param.nom_parametre} ({param.unite})
-              </Tag>
-            ))}
+            <Box className='flex flex-col gap-2'>
+              {historyData?.dailyParameters?.length > 0 && (
+                <Box className='flex flex-wrap gap-1 items-center'>
+                  Journalier : {historyData.dailyParameters.map(param => (
+                    <Tag key={param.paramIndex} sx={{m: 1}}>
+                      {param.nom_parametre} ({param.unite})
+                    </Tag>
+                  ))}
+                </Box>
+              )}
+
+              {dailyParametersAlert && <Alert severity='warning' description={dailyParametersAlert} />}
+
+              {historyData?.fifteenMinutesParameters?.length > 0 && (
+                <Box className='flex flex-wrap gap-1 items-center'>
+                  Quinze minutes : {historyData.fifteenMinutesParameters.map(param => (
+                    <Tag key={param.paramIndex} sx={{m: 1}}>
+                      {param.nom_parametre} ({param.unite})
+                    </Tag>
+                  ))}
+                </Box>
+              )}
+            </Box>
           </Box>
         )}
 
-        {dailyAlert && <Alert severity='warning' description={dailyAlert} />}
-
-        {intervalItems?.length > 0 && (
-          <Box className='flex flex-wrap gap-1 items-center'>
-            Quinze minutes : {intervalItems.map(param => (
-              <Tag key={param.paramIndex} sx={{m: 1}}>
-                {param.nom_parametre} ({param.unite})
-              </Tag>
-            ))}
+        <Box className='flex flex-col gap-4'>
+          <Box className='flex flex-col gap-4'>
+            <Divider textAlign='left'>Calendrier des prélèvements</Divider>
+            {calendarAlert && (
+              <Alert
+                severity='warning'
+                className='mb-2'
+                description={calendarAlert}
+              />
+            )}
+            <PrelevementsCalendar data={historyData} />
           </Box>
-        )}
-      </Box>
-    </Box>
 
-    {calendarData && (
-      <Box className='flex flex-col gap-4'>
-        <Divider textAlign='left'>Calendrier des prélèvements</Divider>
-        {dateAlert && (
-          <Alert
-            severity='warning'
-            className='mb-2'
-            description={dateAlert}
-          />
-        )}
-        <PrelevementsCalendar data={calendarData} />
-      </Box>
-    )}
-
-    {chartData && (
-      <Box className='flex flex-col gap-4'>
-        <Divider textAlign='left'>Graphique de tendance des paramètres</Divider>
-        <ParameterTrendChart data={chartData} connectNulls={connectNulls} />
-      </Box>
+          <Box className='flex flex-col gap-4'>
+            <Divider textAlign='left'>Graphique de tendance des paramètres</Divider>
+            <ParameterTrendChart data={historyData} connectNulls={isTrendChartIgnoringNulls} />
+          </Box>
+        </Box>
+      </>
+    ) : (
+      <Typography>Aucune donnée de prélèvement disponible.</Typography>
     )}
   </Box>
 )

--- a/src/components/ui/PrelevementsHistory/prelevements-history.stories.js
+++ b/src/components/ui/PrelevementsHistory/prelevements-history.stories.js
@@ -7,43 +7,84 @@ const meta = {
   component: PrelevementsHistory,
   tags: ['autodocs'],
   argTypes: {
-    dailyItems: {
-      control: 'object',
-      description: 'Liste des paramètres journaliers à afficher sous forme de tags.'
-    },
-    intervalItems: {
-      control: 'object',
-      description: 'Liste des paramètres à intervalle 15 min à afficher sous forme de tags.'
-    },
-    dailyAlert: {
+    dailyParametersAlert: {
       control: 'text',
-      description: 'Message d’alerte à afficher au niveau des paramètres journaliers.'
+      description: `Message d’alerte à afficher au niveau des **paramètres journaliers**.
+Ex : absence de données ou anomalie globale.`
     },
-    dateAlert: {
+    calendarAlert: {
       control: 'text',
-      description: 'Message d’alerte à afficher au niveau du calendrier.'
+      description: `Message d’alerte à afficher au niveau du **calendrier**.
+Ex : dates manquantes, incohérences, problème de saisie.`
     },
-    calendarData: {
+    historyData: {
       control: 'object',
-      description: 'Données du calendrier des prélèvements (dates, valeurs, etc.).'
+      description: `
+Données du **calendrier des prélèvements**.
+
+Structure attendue :
+
+\`\`\`json
+{
+  "pointPrelevement": "string",
+  "minDate": "YYYY-MM-DD",
+  "maxDate": "YYYY-MM-DD",
+  "dailyParameters": [
+    {
+      "paramIndex": number,
+      "nom_parametre": "string",
+      "type": "string",
+      "unite": "string"
+    }
+  ],
+  "fifteenMinutesParameters": [
+    {
+      "paramIndex": number,
+      "nom_parametre": "string",
+      "type": "string",
+      "unite": "string"
+    }
+  ],
+  "dailyValues": [
+    {
+      "date": "YYYY-MM-DD",
+      "values": [number, ...],
+      "fifteenMinutesValues": [
+        {
+          "heure": "HH:mm:ss",
+          "values": [number|null, ...]
+        }
+      ] | null
+    }
+  ],
+  "volumePreleveTotal": number
+}
+\`\`\`
+
+**Détails des propriétés :**
+- \`pointPrelevement\` : identifiant du point de prélèvement.
+- \`minDate\`, \`maxDate\` : bornes de la période affichée (format "YYYY-MM-DD").
+- \`dailyParameters\` : tableau d’objets décrivant chaque paramètre journalier (index, nom, type, unité).
+- \`fifteenMinutesParameters\` : tableau d’objets décrivant chaque paramètre à intervalle 15 min.
+- \`dailyValues\` : tableau d’objets pour chaque date.
+    - \`date\` : date du prélèvement.
+    - \`values\` : valeurs journalières.
+    - \`fifteenMinutesValues\` : tableau d’objets pour chaque créneau de 15 min (ou null si non applicable).
+        - \`heure\` : heure du créneau (format "HH:mm:ss").
+        - \`values\` : valeurs pour chaque paramètre.
+- \`volumePreleveTotal\` : volume total prélevé sur la période.
+`
     },
-    chartData: {
-      control: 'object',
-      description: 'Données pour le graphique de tendance des paramètres.'
-    },
-    connectNulls: {
+    isTrendChartIgnoringNulls: {
       control: 'boolean',
-      description: 'Relie les points manquants dans le graphique de tendance.'
+      description: 'Relie les points manquants dans le graphique de tendance (`true`) ou laisse des ruptures (`false`).'
     }
   },
   args: {
-    dailyItems: dataTest.dailyItems,
-    intervalItems: dataTest.intervalItems,
-    dailyAlert: null,
-    dateAlert: null,
-    calendarData: dataTest.datesData,
-    chartData: dataTest.datesData,
-    connectNulls: true
+    dailyParametersAlert: '',
+    calendarAlert: '',
+    historyData: dataTest.datesData,
+    isTrendChartIgnoringNulls: true
   }
 }
 
@@ -55,35 +96,27 @@ export const Default = {render: renderPrelevementsHistory}
 
 export const DaysOnly = {
   args: {
-    calendarData: dataTest.datesWithoutIntervals,
-    chartData: dataTest.datesWithoutIntervals,
-    intervalItems: null
+    historyData: dataTest.datesWithoutIntervals
   },
   render: renderPrelevementsHistory
 }
 
 export const WithAlerts = {
   args: {
-    dailyItems: null,
-    intervalItems: [],
-    dailyAlert: 'Aucun paramètre journalier disponible',
-    dateAlert: 'Attention, certaines dates sont manquantes',
-    calendarData: dataTest.datesData,
-    chartData: dataTest.datesData,
-    connectNulls: false
+    dailyParametersAlert: 'Aucun paramètre journalier disponible',
+    calendarAlert: 'Attention, certaines dates sont manquantes',
+    historyData: dataTest.datesData,
+    isTrendChartIgnoringNulls: false
   },
   render: renderPrelevementsHistory
 }
 
 export const withoutData = {
   args: {
-    dailyItems: null,
-    intervalItems: [],
-    dailyAlert: null,
-    dateAlert: null,
-    calendarData: null,
-    chartData: null,
-    connectNulls: false
+    dailyParametersAlert: null,
+    calendarAlert: null,
+    historyData: null,
+    isTrendChartIgnoringNulls: false
   },
   render: renderPrelevementsHistory
 }


### PR DESCRIPTION
Cette *pull request* refactorise le composant `PrelevementsHistory` ainsi que ses stories dans Storybook afin de simplifier la gestion des données et d’améliorer la clarté.  
Le principal changement est la consolidation de plusieurs props en un seul objet `historyData`, accompagné du renommage et de la restructuration des props liées aux alertes et aux graphiques.  
Cela rationalise l’interface du composant et rend la structure de données attendue plus explicite pour les développements et la documentation futurs.  

## 🔧 Refactorisation de l’API du composant et consolidation des données

- Le composant `PrelevementsHistory` reçoit désormais une seule prop `historyData` contenant toutes les données pertinentes (paramètres, calendrier, graphique, etc.), en remplacement des multiples props séparées (`dailyItems`, `intervalItems`, `calendarData`, `chartData`).  
- Les props liées aux alertes ont également été renommées pour plus de clarté (`dailyParametersAlert`, `calendarAlert`).  

## 📖 Mise à jour de la documentation et des usages dans Storybook

- Les `argTypes` et exemples de stories dans Storybook ont été mis à jour pour refléter la nouvelle structure des props, incluant une description détaillée et la structure JSON attendue de `historyData`.  
- Les anciennes props ont été supprimées et remplacées par les nouvelles consolidées.  
- Toutes les stories Storybook (`DaysOnly`, `WithAlerts`, `WithoutData`) utilisent désormais `historyData` et les nouvelles props renommées, garantissant cohérence et bonne démonstration de l’API refactorisée du composant.  

## 🎨 Améliorations de la logique de rendu du composant

- La logique de rendu dans `PrelevementsHistory` a été adaptée pour utiliser la nouvelle structure `historyData`.  
- Le rendu conditionnel est appliqué à chaque section (paramètres, calendrier, graphique de tendance) en fonction de la présence des données correspondantes.  
- Un message de repli est affiché lorsqu’aucune donnée n’est disponible.  
