### PR TITLE
Formulaire exploitations : Point par ordre alphabétique + corrections

### DIFF
--- a/src/app/exploitations/[id]/edit/page.js
+++ b/src/app/exploitations/[id]/edit/page.js
@@ -20,6 +20,18 @@ const Page = async ({params}) => {
   const points = await getPointsPrelevement()
   const preleveurs = await getPreleveurs()
 
+  const orderedPoints = points.sort((a, b) => {
+    if (a.nom < b.nom) {
+      return -1
+    }
+
+    if (a.nom > b.nom) {
+      return 1
+    }
+
+    return 0
+  })
+
   return (
     <div>
       <StartDsfrOnHydration />
@@ -34,7 +46,7 @@ const Page = async ({params}) => {
       </div>
       <ExploitationEditionForm
         exploitation={exploitation}
-        points={points}
+        points={orderedPoints}
         preleveurs={preleveurs}
       />
     </div>

--- a/src/components/form/exploitation-creation-form.js
+++ b/src/components/form/exploitation-creation-form.js
@@ -42,8 +42,7 @@ const ExploitationCreationForm = ({idPoint, points, preleveurs}) => {
           setError(response.message)
         }
       } else {
-        // TODO : Rediriger vers la page exploitation quand elle sera terminée
-        router.push(`/prelevements/${response.point}`)
+        router.push(`/exploitations/${response.id_exploitation}`)
       }
     } catch (error) {
       setError(error.message)

--- a/src/components/form/exploitation-form.js
+++ b/src/components/form/exploitation-form.js
@@ -45,7 +45,9 @@ const ExploitationForm = ({exploitation, points, preleveurs, setExploitation, id
   const [isStatutAbandonnee, setIsStatutAbandonnee] = useState(exploitation?.statut === 'Abandonnée')
   const initialUsages = exploitation?.usages || []
   const [usages, setUsages] = useState(exploitation?.usages || [])
-  const defaultPoint = points.find(p => p._id === (exploitation?.point || idPoint))
+  const defaultPoint = points.find(
+    p => p._id === exploitation?.point || p.id_point === Number(idPoint)
+  )
   const defaultPreleveur = preleveurs.find(p => p._id === exploitation?.preleveur)
 
   const handleUsages = (e, usage) => {
@@ -69,6 +71,12 @@ const ExploitationForm = ({exploitation, points, preleveurs, setExploitation, id
     }
   }, [usages, setExploitation, hasUsagesChanged])
 
+  useEffect(() => {
+    if (defaultPoint) {
+      setExploitation(prev => ({...prev, point: defaultPoint._id}))
+    }
+  }, [defaultPoint, setExploitation])
+
   return (
     <div>
       <div className='w-full grid grid-cols-2 gap-4 pb-5'>
@@ -80,10 +88,10 @@ const ExploitationForm = ({exploitation, points, preleveurs, setExploitation, id
               <SearchAutocomplete
                 options={points.map(point => ({
                   point,
-                  label: `${point.nom} - ${point.id_point}`
+                  label: `${point.id_point} - ${point.nom}`
                 }))}
                 defaultValue={defaultPoint
-                  ? `${defaultPoint.nom} - ${defaultPoint.id_point}`
+                  ? `${defaultPoint.id_point} - ${defaultPoint.nom}`
                   : null}
                 className={className}
                 id={id}


### PR DESCRIPTION
En rapport avec l'issue #139 : 

- Les points sont classés par ordre alphabétique dans la liste déroulante
- Le numéro du point est affiché en premier
- Correction d'un bug entre `point._id` (pour la base de données) et `point.id_point` pour l'affichage
- Correction du lien de redirection après création ou suppression d'un point

