### PR TITLE
Composant CompactAlert

### DIFF
--- a/src/components/ui/CompactAlert/compact-alert.stories.js
+++ b/src/components/ui/CompactAlert/compact-alert.stories.js
@@ -1,0 +1,38 @@
+import CompactAlert from './index.js'
+
+const storyMeta = {
+  title: 'Components/CompactAlert',
+  component: CompactAlert,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Texte affiché dans l’alerte.'
+    },
+    alertType: {
+      control: {type: 'select'},
+      options: ['info', 'warning', 'error', 'missing'],
+      description: 'Type d’alerte (définit l’icône et la couleur).'
+    }
+  },
+  args: {
+    label: 'Ceci est une alerte de type "info"',
+    alertType: 'info'
+  }
+}
+
+export default storyMeta
+
+export const Info = args => <CompactAlert {...args} />
+
+export const Alerte = args => (
+  <CompactAlert {...args} alertType='warning' label='Ceci est une alerte de type "warning"' />
+)
+
+export const Erreur = args => (
+  <CompactAlert {...args} alertType='error' label='Ceci est une alerte de type "error"' />
+)
+
+export const DonnéesManquantes = args => (
+  <CompactAlert {...args} alertType='missing' label='Ceci est une alerte de type "missing"' />
+)

--- a/src/components/ui/CompactAlert/index.js
+++ b/src/components/ui/CompactAlert/index.js
@@ -1,0 +1,37 @@
+import {fr} from '@codegouvfr/react-dsfr'
+import {Box, Typography} from '@mui/material'
+
+const icons = {
+  info: 'fr-icon-info-fill',
+  warning: 'fr-icon-warning-fill',
+  error: 'fr-icon-error-fill',
+  missing: 'fr-icon-close-circle-fill'
+}
+
+const colors = {
+  info: fr.colors.decisions.text.default.info.default,
+  warning: fr.colors.decisions.text.default.warning.default,
+  error: fr.colors.decisions.text.default.error.default,
+  missing: fr.colors.decisions.text.mention.grey.default
+}
+
+const CompactAlert = ({label, alertType = 'info'}) => {
+  const type = icons[alertType] ? alertType : 'info'
+
+  return (
+    <Box
+      className='flex items-center gap-1'
+      role='alert'
+      sx={{borderColor: colors[type]}}
+    >
+      <span
+        className={icons[type]}
+        aria-hidden='true'
+        style={{color: colors[type]}}
+      />
+      <Typography variant='body2'>{label}</Typography>
+    </Box>
+  )
+}
+
+export default CompactAlert


### PR DESCRIPTION
Cette pull request introduit un nouveau composant **`CompactAlert`** dans l’UI ainsi que ses stories Storybook, permettant un affichage compacte de différents messages d’alerte.

### Ajout du composant

- Ajout du nouveau composant `CompactAlert` dans `src/components/ui/CompactAlert/index.js`, prenant en charge quatre types d’alerte (`info`, `warning`, `error`, `missing`) avec les icônes et couleurs issues du design system DSFR.

### Intégration Storybook

- Création des stories pour chaque type d’alerte, permettant un aperçu interactif et la documentation du composant `CompactAlert`.

Composant utilisé notamment pout le futur dans le calendrier des prélèvements #223.
<img width="1128" height="1062" alt="Capture d’écran 2025-09-18 à 17 00 47" src="https://github.com/user-attachments/assets/ff2c2c35-0243-4bc9-81f6-e52e253d4a1a" />

Close #227
