### PR TITLE
Ajout du composans UI PeriodTooltip

### DIFF
--- a/src/components/ui/PeriodTooltip/index.js
+++ b/src/components/ui/PeriodTooltip/index.js
@@ -42,9 +42,9 @@ const PeriodTooltip = ({periodLabel, parameters, alerts, children}) => {
         >
           <Typography sx={{fontWeight: 'bold'}}>{periodLabel}</Typography>
           <Box sx={{display: 'flex', flexDirection: 'column', gap: 2}}>
-            {parameters?.length && <MetasList metas={parameters} />}
+            {(parameters?.length > 0) && <MetasList metas={parameters} />}
 
-            {alerts?.length && (
+            {(alerts?.length > 0) && (
               <Box>
                 {uniqBy(alerts, 'alertLabel').map(alert => (
                   <CompactAlert

--- a/src/components/ui/PeriodTooltip/index.js
+++ b/src/components/ui/PeriodTooltip/index.js
@@ -1,7 +1,7 @@
 import {useState, useId} from 'react'
 
 import {Popover, Typography, Box} from '@mui/material'
-import {uniqueId} from 'lodash-es'
+import {uniqBy} from 'lodash-es'
 
 import CompactAlert from '@/components/ui/CompactAlert/index.js'
 import MetasList from '@/components/ui/MetasList/index.js'
@@ -42,13 +42,13 @@ const PeriodTooltip = ({periodLabel, parameters, alerts, children}) => {
         >
           <Typography sx={{fontWeight: 'bold'}}>{periodLabel}</Typography>
           <Box sx={{display: 'flex', flexDirection: 'column', gap: 2}}>
-            {parameters?.length > 0 && <MetasList metas={parameters} />}
+            {parameters?.length && <MetasList metas={parameters} />}
 
-            {alerts?.length > 0 && (
+            {alerts?.length && (
               <Box>
-                {alerts.map(alert => (
+                {uniqBy(alerts, 'alertLabel').map(alert => (
                   <CompactAlert
-                    key={uniqueId()}
+                    key={alert.alertLabel}
                     label={alert.alertLabel}
                     alertType={alert.alertType}
                   />

--- a/src/components/ui/PeriodTooltip/index.js
+++ b/src/components/ui/PeriodTooltip/index.js
@@ -1,0 +1,65 @@
+import {useState, useId} from 'react'
+
+import {Popover, Typography, Box} from '@mui/material'
+import {uniqueId} from 'lodash-es'
+
+import CompactAlert from '@/components/ui/CompactAlert/index.js'
+import MetasList from '@/components/ui/MetasList/index.js'
+
+const PeriodTooltip = ({periodLabel, parameters, alerts, children}) => {
+  const [anchorEl, setAnchorEl] = useState(null)
+  const popoverId = useId()
+
+  const handlePopoverOpen = event => setAnchorEl(event.currentTarget)
+  const handlePopoverClose = () => setAnchorEl(null)
+  const open = Boolean(anchorEl)
+
+  return (
+    <>
+      <span
+        style={{display: 'inline-block'}}
+        onMouseEnter={handlePopoverOpen}
+        onMouseLeave={handlePopoverClose}
+      >
+        {children}
+      </span>
+      <Popover
+        disableRestoreFocus
+        id={popoverId}
+        sx={{
+          pointerEvents: 'none',
+          '& .MuiPaper-root:focus': {outline: 'none'}
+        }}
+        open={open}
+        anchorEl={anchorEl}
+        anchorOrigin={{vertical: 'top', horizontal: 'center'}}
+        transformOrigin={{vertical: 'bottom', horizontal: 'center'}}
+        onClose={handlePopoverClose}
+      >
+        <Box sx={{
+          p: 1, display: 'flex', flexDirection: 'column', gap: 1
+        }}
+        >
+          <Typography sx={{fontWeight: 'bold'}}>{periodLabel}</Typography>
+          <Box sx={{display: 'flex', flexDirection: 'column', gap: 2}}>
+            {parameters?.length > 0 && <MetasList metas={parameters} />}
+
+            {alerts?.length > 0 && (
+              <Box>
+                {alerts.map(alert => (
+                  <CompactAlert
+                    key={uniqueId()}
+                    label={alert.alertLabel}
+                    alertType={alert.alertType}
+                  />
+                ))}
+              </Box>
+            )}
+          </Box>
+        </Box>
+      </Popover>
+    </>
+  )
+}
+
+export default PeriodTooltip

--- a/src/components/ui/PeriodTooltip/period-tooltip.stories.js
+++ b/src/components/ui/PeriodTooltip/period-tooltip.stories.js
@@ -17,7 +17,7 @@ const storyMeta = {
   \`\`\`json
    [
       {
-        "icon": <Icône>,
+        "icon": <Icon>,
         "content": <string>
       }
     ]

--- a/src/components/ui/PeriodTooltip/period-tooltip.stories.js
+++ b/src/components/ui/PeriodTooltip/period-tooltip.stories.js
@@ -1,0 +1,95 @@
+import {WaterDropOutlined} from '@mui/icons-material'
+
+import PeriodTooltip from './index.js'
+
+const storyMeta = {
+  title: 'Components/PeriodTooltip',
+  component: PeriodTooltip,
+  tags: ['autodocs'],
+  argTypes: {
+    periodLabel: {
+      control: 'text',
+      description: 'Libellé de la période affichée dans l’info-bulle. Exemple : "2025", "Janvier 2024", "2023-2024"...'
+    },
+    parameters: {
+      control: 'object',
+      description: `Paramètres à afficher dans l’info-bulle.
+  \`\`\`json
+   [
+      {
+        "icon": <Icône>,
+        "content": <string>
+      }
+    ]
+    \`\`\`
+`
+    },
+    alerts: {
+      control: 'array',
+      description: `Tableau d’alertes à afficher dans l’info-bulle.
+\`\`\`json
+[
+  {
+    "alertLabel": <string>,
+    "alertType": "info" | "warning" | "missing"
+  }
+]
+  \`\`\`
+  `
+    },
+    children: {
+      control: 'text',
+      description: 'Contenu affiché qui déclenche l’info-bulle.'
+    }
+  },
+  args: {
+    periodLabel: '2025',
+    parameters: [{icon: WaterDropOutlined, content: '12 900 m3 de volume prélevé'}],
+    alerts: [
+      {alertLabel: '4 mois avec absence de prélèvement', alertType: 'info'},
+      {alertLabel: '1 mois avec alertes', alertType: 'warning'},
+      {alertLabel: '2 mois sans déclaration', alertType: 'missing'}
+    ],
+    children: 'Survoler pour en savoir plus'
+  }
+}
+
+export default storyMeta
+
+const renderPrelevementsHistory = args => <PeriodTooltip {...args} />
+
+export const Default = {render: renderPrelevementsHistory}
+
+export const SansParametres = {
+  args: {
+    parameters: null,
+    children: 'Les paramètres ne seront pas affichés dans l’info-bulle'
+  },
+  render: renderPrelevementsHistory
+}
+
+export const SansAlertes = {
+  args: {
+    alerts: null,
+    children: 'Les alertes ne seront pas affichées dans l’info-bulle'
+  },
+  render: renderPrelevementsHistory
+}
+
+export const SansParametresEtSansAlertes = {
+  args: {
+    parameters: null,
+    alerts: null,
+    children: 'Les paramètres et les alertes ne seront pas affichés dans l’info-bulle'
+  },
+  render: renderPrelevementsHistory
+}
+
+export const AvecDesLabelsLongs = {
+  args: {
+    periodLabel: 'Période de prélèvement 2023-2024',
+    children: 'Le label de la période peut être plus long'
+  },
+  render: renderPrelevementsHistory
+}
+


### PR DESCRIPTION
Cette pull request introduit un nouveau composant UI réutilisable pour afficher des informations détaillées sur une période dans une info-bulle, ainsi que des stories Storybook complètes pour démontrer son utilisation et couvrir les cas limites. Ces changements améliorent la capacité de l’application à afficher des données contextuelles et des alertes liées aux périodes de manière cohérente et interactive.

**Nouveau composant UI :**

- Ajout du composant `PeriodTooltip` dans `src/components/ui/PeriodTooltip/index.js`, qui affiche une info-bulle contenant un libellé de période, des paramètres et des alertes lors du survol de ses enfants.  
  Il utilise le `Popover` de MUI, prend en charge du contenu dynamique et s’intègre avec `MetasList` et `CompactAlert` pour le rendu des paramètres et des alertes.

**Intégration et documentation Storybook :**

- Création des stories Storybook pour présenter le composant `PeriodTooltip`, y compris :  
  - l’utilisation par défaut,  
  - les variantes sans paramètres ni alertes,  
  - et la gestion des libellés de période longs.  

Ces stories fournissent une documentation claire et des exemples de configuration pour les développeurs.

<img width="1080" height="861" alt="Capture d’écran 2025-09-19 à 09 13 53" src="https://github.com/user-attachments/assets/61b243e9-18ca-45d3-9c48-f56fab8a141c" />

Close issue #226 
Related to issue #223 
